### PR TITLE
Add dark mode toggle to flashcards page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,3 +4,72 @@ body {
   padding: 0;
   background-color: #f7f7f7;
 }
+
+/* Dark mode */
+body.dark {
+  background-color: #1a1a1a;
+  color: #f0f0f0;
+}
+
+body.dark a {
+  color: #9bd1ff;
+}
+
+body.dark input,
+body.dark textarea {
+  background-color: #333;
+  color: #f0f0f0;
+  border-color: #555;
+}
+
+body.dark button {
+  background-color: #444;
+  color: #f0f0f0;
+}
+
+/* Toggle switch styles */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  margin-right: 0.5rem;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 34px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: #2196f3;
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
+}

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -12,6 +12,21 @@ interface Flashcard {
 const FlashcardsPage: React.FC = () => {
   const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [darkMode, setDarkMode] = useState<boolean>(false);
+
+  // Load dark mode preference from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem('darkMode');
+    if (stored) {
+      setDarkMode(stored === 'true');
+    }
+  }, []);
+
+  // Apply dark mode class to body
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+    localStorage.setItem('darkMode', darkMode.toString());
+  }, [darkMode]);
 
   const loadFlashcards = () => {
     axios
@@ -46,6 +61,17 @@ const FlashcardsPage: React.FC = () => {
 
   return (
     <div className="p-4">
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
+        <label className="switch">
+          <input
+            type="checkbox"
+            checked={darkMode}
+            onChange={() => setDarkMode(!darkMode)}
+          />
+          <span className="slider" />
+        </label>
+        <span>Dark Mode</span>
+      </div>
       <h1 className="text-2xl font-bold mb-4">Your Flashcards</h1>
       <FlashcardForm onSuccess={loadFlashcards} />
 


### PR DESCRIPTION
## Summary
- add dark mode styles and switch CSS
- implement dark mode toggle on the flashcards page

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8664040832f9330511720af67e3