### PR TITLE
Improve frontend layout

### DIFF
--- a/frontend/src/components/FlashcardForm.tsx
+++ b/frontend/src/components/FlashcardForm.tsx
@@ -29,8 +29,8 @@ const FlashcardForm: React.FC<Props> = ({ onSuccess }) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '2rem' }}>
-      <h2>Add a New Flashcard</h2>
+    <form onSubmit={handleSubmit} style={{ marginBottom: '2rem' }} className="card">
+      <h2 className="text-lg font-semibold mb-2">Add a New Flashcard</h2>
       <input
         type="text"
         placeholder="Concept"
@@ -38,7 +38,7 @@ const FlashcardForm: React.FC<Props> = ({ onSuccess }) => {
         onChange={(e) => setConcept(e.target.value)}
         required
         style={{ display: 'block', marginBottom: '0.5rem', width: '100%' }}
-      />
+        />
       <textarea
         placeholder="Definition"
         value={definition}
@@ -54,7 +54,7 @@ const FlashcardForm: React.FC<Props> = ({ onSuccess }) => {
         onChange={(e) => setTags(e.target.value)}
         style={{ display: 'block', marginBottom: '0.5rem', width: '100%' }}
       />
-      <button type="submit">Add Flashcard</button>
+      <button type="submit" className="btn mt-2">Add Flashcard</button>
     </form>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -73,3 +73,44 @@ input:checked + .slider {
 input:checked + .slider:before {
   transform: translateX(20px);
 }
+
+/* Simple utility classes */
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.btn {
+  background-color: #3b82f6;
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background-color: #2563eb;
+}
+
+.btn-secondary {
+  background-color: #6b7280;
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  background-color: #4b5563;
+}

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -72,7 +72,7 @@ const FlashcardsPage: React.FC = () => {
     
 
   return (
-    <div className="p-4">
+    <div className="container">
       <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
         <label className="switch">
           <input
@@ -94,9 +94,7 @@ const FlashcardsPage: React.FC = () => {
           <strong>Filter by tag:</strong>{' '}
           <button
             onClick={() => setSelectedTag(null)}
-            className={`mr-2 px-2 py-1 border rounded ${
-              selectedTag === null ? 'bg-blue-200' : ''
-            }`}
+            className={`btn-secondary mr-2 ${selectedTag === null ? 'opacity-70' : ''}`}
           >
             All
           </button>
@@ -104,9 +102,7 @@ const FlashcardsPage: React.FC = () => {
             <button
               key={tag}
               onClick={() => setSelectedTag(tag)}
-              className={`mr-2 px-2 py-1 border rounded ${
-                selectedTag === tag ? 'bg-blue-300' : ''
-              }`}
+              className={`btn-secondary mr-2 ${selectedTag === tag ? 'opacity-70' : ''}`}
             >
               {tag}
             </button>
@@ -116,7 +112,7 @@ const FlashcardsPage: React.FC = () => {
 
       <ul>
         {visibleFlashcards.map((card) => (
-          <li key={card.id} className="mb-3 p-3 border rounded shadow">
+          <li key={card.id} className="card">
           <div className="font-semibold">{card.concept}</div>
           <div className="text-gray-700">{card.definition}</div>
           <div className="text-sm text-blue-600 mt-1">
@@ -132,19 +128,17 @@ const FlashcardsPage: React.FC = () => {
           <div><strong>Next Review:</strong> {card.next_review_date ? new Date(card.next_review_date).toLocaleString() : "Not reviewed yet"}</div>
           <button
             onClick={() => {
-              axios.post(`http://localhost:8000/flashcards/${card.id}/mark-reviewed`)
+              axios
+                .post(`http://localhost:8000/flashcards/${card.id}/mark-reviewed`)
                 .then(() => loadFlashcards())
                 .catch((err) => console.error('Error marking reviewed:', err));
             }}
-            className="text-sm text-blue-600 hover:underline"
+            className="btn-secondary mr-2"
           >
             Mark Reviewed
           </button>
 
-          <button
-            onClick={() => handleDelete(card.id)}
-            className="mt-2 px-2 py-1 text-sm bg-red-500 text-white rounded"
-          >
+          <button onClick={() => handleDelete(card.id)} className="btn">
             Delete
           </button>
         </li>

--- a/frontend/src/pages/ManualReviewPage.tsx
+++ b/frontend/src/pages/ManualReviewPage.tsx
@@ -41,16 +41,16 @@ const ManualReviewPage: React.FC = () => {
   };
 
   return (
-    <div className="p-6">
+    <div className="container">
       <h2 className="text-2xl font-bold mb-4">Manual Review</h2>
 
       {!selectedCard ? (
         <ul>
           {flashcards.map((card) => (
-            <li key={card.id} className="mb-2 border p-2 rounded">
+            <li key={card.id} className="card">
               <strong>{card.concept}</strong>
               <button
-                className="ml-4 px-2 py-1 bg-blue-500 text-white rounded"
+                className="btn ml-4"
                 onClick={() => {
                   setSelectedCard(card);
                   setFeedback(null);
@@ -62,7 +62,7 @@ const ManualReviewPage: React.FC = () => {
           ))}
         </ul>
       ) : (
-        <div className="border p-4 rounded">
+        <div className="card">
           <div className="mb-2"><strong>Concept:</strong> {selectedCard.concept}</div>
           <textarea
             className="w-full p-2 border rounded mb-2"
@@ -71,10 +71,10 @@ const ManualReviewPage: React.FC = () => {
             onChange={(e) => setAnswer(e.target.value)}
           />
           <div className="flex gap-2">
-            <button className="bg-green-600 text-white px-4 py-1 rounded" onClick={handleReview}>
+            <button className="btn" onClick={handleReview}>
               Submit Answer
             </button>
-            <button className="bg-gray-400 text-white px-4 py-1 rounded" onClick={() => setSelectedCard(null)}>
+            <button className="btn-secondary" onClick={() => setSelectedCard(null)}>
               Cancel
             </button>
           </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -39,73 +39,71 @@ const ProfilePage: React.FC = () => {
   if (!profile) return <div>Loading...</div>;
 
   return (
-    <div className="p-4">
+    <div className="container">
       <h1 className="text-2xl font-bold mb-4">User Profile</h1>
 
-      <div className="mb-4">
-        <label>Name:</label>
-        <input
-          name="name"
-          value={profile.name}
-          onChange={handleChange}
-          className="border p-1 ml-2"
-        />
+      <div className="card">
+        <div className="mb-4">
+          <label>Name:</label>
+          <input
+            name="name"
+            value={profile.name}
+            onChange={handleChange}
+            className="border p-1 ml-2"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label>Study Mode:</label>
+          <select
+            name="study_mode"
+            value={profile.study_mode}
+            onChange={handleChange}
+            className="border p-1 ml-2"
+          >
+            <option value="batch">Batch</option>
+            <option value="distributed">Distributed</option>
+          </select>
+        </div>
+
+        <div className="mb-4">
+          <label>Start Hour:</label>
+          <input
+            type="number"
+            name="preferred_start_hour"
+            value={profile.preferred_start_hour}
+            onChange={handleChange}
+            className="border p-1 ml-2"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label>End Hour:</label>
+          <input
+            type="number"
+            name="preferred_end_hour"
+            value={profile.preferred_end_hour}
+            onChange={handleChange}
+            className="border p-1 ml-2"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label>Timezone:</label>
+          <input
+            name="timezone"
+            value={profile.timezone}
+            onChange={handleChange}
+            className="border p-1 ml-2"
+          />
+        </div>
+
+        <button onClick={handleSave} className="btn" disabled={isSaving}>
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+
+        {message && <p className="mt-2">{message}</p>}
       </div>
-
-      <div className="mb-4">
-        <label>Study Mode:</label>
-        <select
-          name="study_mode"
-          value={profile.study_mode}
-          onChange={handleChange}
-          className="border p-1 ml-2"
-        >
-          <option value="batch">Batch</option>
-          <option value="distributed">Distributed</option>
-        </select>
-      </div>
-
-      <div className="mb-4">
-        <label>Start Hour:</label>
-        <input
-          type="number"
-          name="preferred_start_hour"
-          value={profile.preferred_start_hour}
-          onChange={handleChange}
-          className="border p-1 ml-2"
-        />
-      </div>
-
-      <div className="mb-4">
-        <label>End Hour:</label>
-        <input
-          type="number"
-          name="preferred_end_hour"
-          value={profile.preferred_end_hour}
-          onChange={handleChange}
-          className="border p-1 ml-2"
-        />
-      </div>
-
-      <div className="mb-4">
-        <label>Timezone:</label>
-        <input
-          name="timezone"
-          value={profile.timezone}
-          onChange={handleChange}
-          className="border p-1 ml-2"
-        />
-      </div>
-
-      <button
-        onClick={handleSave}
-        className="px-4 py-2 bg-blue-500 text-white rounded"
-        disabled={isSaving}
-      >
-        {isSaving ? 'Saving...' : 'Save'}
-      </button>
-
-      {message && <p className="mt-2">{message}</p>}
     </div>
   );
 };

--- a/frontend/src/pages/ReviewHistoryPage.tsx
+++ b/frontend/src/pages/ReviewHistoryPage.tsx
@@ -24,11 +24,11 @@ const ReviewHistoryPage: React.FC = () => {
   }, []);
 
   return (
-    <div className="p-4">
+    <div className="container">
       <h2 className="text-2xl font-bold mb-4">Review History</h2>
       <ul>
         {reviews.map((r) => (
-          <li key={r.id} className="mb-3 p-3 border rounded shadow">
+          <li key={r.id} className="card">
             <div><strong>Concept:</strong> {r.flashcard?.concept || 'Unknown'}</div>
             <div><strong>Your Answer:</strong> {r.user_response}</div>
             <div><strong>Result:</strong> {r.was_correct ? '✅ Correct' : '❌ Incorrect'}</div>


### PR DESCRIPTION
## Summary
- add utility classes for cards, buttons, and container
- apply styling across Flashcards, Profile, Review History, and Manual Review pages
- improve Flashcard form appearance

## Testing
- `pytest -q`
- `npm test --silent` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848d3158738832f9a1968e08510d6e9